### PR TITLE
Turn off homebrew analytics when auto brewing

### DIFF
--- a/default
+++ b/default
@@ -5,6 +5,7 @@ rm -Rf $BREWDIR
 mkdir -p $BREWDIR
 echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
 curl -fsSL https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
+$BREW analytics off
 BREW_DEPS=$($BREW deps -n $PKG_BREW_NAME)
 HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
 rm -f $BREWDIR/Cellar/$PKG_BREW_NAME/*/lib/*.dylib


### PR DESCRIPTION
Some users may not appreciate the anonymous usage statistics being on when auto-brewing.

I made the change only for the default script, if you agree it should be done for the rest as well, not sure if they are derived or if you have to edit by hand.