### PR TITLE
Opt out of homebrew analytics using the environment variable

### DIFF
--- a/default
+++ b/default
@@ -5,7 +5,7 @@ rm -Rf $BREWDIR
 mkdir -p $BREWDIR
 echo "Auto-brewing $PKG_BREW_NAME in $BREWDIR..."
 curl -fsSL https://github.com/Homebrew/brew/tarball/master | tar xz --strip 1 -C $BREWDIR
-$BREW analytics off >/dev/null 2>&1
+export HOMEBREW_NO_ANALYTICS=1
 $BREW update
 BREW_DEPS=$($BREW deps -n $PKG_BREW_NAME)
 HOMEBREW_CACHE="$AUTOBREW" $BREW install --force-bottle $BREW_DEPS $PKG_BREW_NAME 2>&1 | perl -pe 's/Warning/Note/gi'
@@ -20,3 +20,4 @@ if [ "$PKG_LIBS_STATIC" ]; then
 PKG_LIBS=$PKG_LIBS_STATIC
 fi
 
+unset HOMEBREW_NO_ANALYTICS


### PR DESCRIPTION
using `brew analytics off` didn't seem to actually work, looks like there is an issue with setting up the initial git config

```
error: could not lock config file .../.git/config: No such file or directory
Error: Failure while executing: git config --file=.../.git/config --replace-all homebrew.analyticsdisabled true
```

You can also see analytics are still enabled from the [output](https://www.r-project.org/nosvn/R.check/r-release-osx-x86_64/odbc-00install.html)
> ==> Homebrew has enabled anonymous aggregate user behaviour analytics.
> Read the analytics documentation (and how to opt-out) here:
>   https://docs.brew.sh/Analytics.html

Anyway just using the environment variable instead does work.