### PR TITLE
v8: make it work on Mojave

### DIFF
--- a/v8
+++ b/v8
@@ -2,7 +2,7 @@ export HOMEBREW_NO_ANALYTICS=1
 export HOMEBREW_NO_AUTO_UPDATE=1
 
 # Offical Homebrew no longer supports El-Capitain
-if [ $(sw_vers -productVersion | grep "10\\.1[123]") ]; then
+if [ $(sw_vers -productVersion | grep "10\\.1[1-4]") ]; then
 UPSTREAM_ORG="autobrew"
 else
 UPSTREAM_ORG="Homebrew"


### PR DESCRIPTION
Fix the following error when installing the "V8" R package on OSX Mojave:

```
ld: warning: directory not found for option '-L/var/folders/yb/vc950hrs225_j49yhntvv0140000gn/T//build-v8/opt/v8/lib'
ld: library not found for -lv8_base
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [V8.so] Error 1
ERROR: compilation failed for package ‘V8’
* removing ‘/Users/user/Library/R/3.5/library/V8’
* restoring previous ‘/Users/user/Library/R/3.5/library/V8’
```

It's pulling the wrong brew; ProductVersion for Mojave is now at:

```
macbookpro:autobrew$ sw_vers
ProductName:    Mac OS X
ProductVersion: 10.14.6
BuildVersion:   18G87
```


Thanks!